### PR TITLE
Address <<-EOS.undent deprecations, update syntax to <<~EOS

### DIFF
--- a/cev.rb
+++ b/cev.rb
@@ -8,7 +8,7 @@ class Cev < Formula
     bin.install "cev"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Secure Keyboard Entry must be disabled. Cev must be ran as root!
     EOS
   end

--- a/khd.rb
+++ b/khd.rb
@@ -14,7 +14,7 @@ class Khd < Formula
     (pkgshare/"examples").install "#{buildpath}/examples/khdrc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Copy the example configuration into your home directory:
       cp #{opt_pkgshare}/examples/khdrc ~/.khdrc
 
@@ -26,7 +26,7 @@ class Khd < Formula
   plist_options :manual => "khd"
 
   if build.with? "logging"
-      def plist; <<-EOS.undent
+      def plist; <<~EOS
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
@@ -65,7 +65,7 @@ class Khd < Formula
         EOS
       end
   else
-      def plist; <<-EOS.undent
+      def plist; <<~EOS
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">

--- a/kwm.rb
+++ b/kwm.rb
@@ -11,7 +11,7 @@ class Kwm < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
@@ -41,7 +41,7 @@ class Kwm < Formula
     EOS
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Copy the example config from #{prefix}/kwmrc into your home directory.
       mkdir -p ~/.kwm
       cp #{prefix}/kwmrc ~/.kwm/kwmrc

--- a/skhd.rb
+++ b/skhd.rb
@@ -15,7 +15,7 @@ class Skhd < Formula
     (pkgshare/"examples").install "#{buildpath}/examples/skhdrc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Copy the example configuration into your home directory:
       cp #{opt_pkgshare}/examples/skhdrc ~/.skhdrc
 
@@ -27,7 +27,7 @@ class Skhd < Formula
   plist_options :manual => "skhd"
 
   if build.with? "logging"
-      def plist; <<-EOS.undent
+      def plist; <<~EOS
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
@@ -56,7 +56,7 @@ class Skhd < Formula
         EOS
       end
   else
-      def plist; <<-EOS.undent
+      def plist; <<~EOS
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">


### PR DESCRIPTION
I was receiving some warnings when checking for updates of `khd` related to the use of `<<-EOS.undent`, which seems to have been deprecated:

```
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/koekeishiya/homebrew-formulae/khd.rb:100:in `plist'
Please report this to the koekeishiya/formulae tap!
```

This pull request implements the suggested update in the warning message and changes all usages of`<<-EOS.undent` to `<<~EOS` in all brew formulae kept in this repo.