### PR TITLE
Add git-lfs dependency when building from source

### DIFF
--- a/yabai.rb
+++ b/yabai.rb
@@ -6,6 +6,7 @@ class Yabai < Formula
   head "https://github.com/koekeishiya/yabai.git"
 
   depends_on :macos => :high_sierra
+  depends_on "git-lfs" => :build
 
   def install
     (var/"log/yabai").mkpath


### PR DESCRIPTION
Fixes koekeishiya/yabai#248

Sorry about this one, I knew I forgot something.

Large file storage is configured to be used for all PNG images so they don't need to be diffed by git.