### PR TITLE
Add interactive process type + set niceness to highest prio.

### DIFF
--- a/skhd.rb
+++ b/skhd.rb
@@ -50,7 +50,11 @@ class Skhd < Formula
           <key>StandardOutPath</key>
           <string>#{var}/log/skhd/skhd.out.log</string>
           <key>StandardErrorPath</key>
-          <string>#{var}/log/skhd/skhd.err.log</string>
+          <string>#{var}/log/skhd/skhd.err.log</string>      
+          <key>ProcessType</key>
+          <string>Interactive</string>          
+          <key>Nice</key>
+          <integer>-20</integer>
         </dict>
         </plist>
         EOS
@@ -76,6 +80,10 @@ class Skhd < Formula
           <true/>
           <key>KeepAlive</key>
           <true/>
+          <key>ProcessType</key>
+          <string>Interactive</string>      
+          <key>Nice</key>
+          <integer>-20</integer>
         </dict>
         </plist>
         EOS

--- a/yabai.rb
+++ b/yabai.rb
@@ -58,6 +58,10 @@ class Yabai < Formula
       <string>#{var}/log/yabai/yabai.out.log</string>
       <key>StandardErrorPath</key>
       <string>#{var}/log/yabai/yabai.err.log</string>
+      <key>ProcessType</key>
+      <string>Interactive</string>
+      <key>Nice</key>
+      <integer>-20</integer>
     </dict>
     </plist>
     EOS


### PR DESCRIPTION
@koekeishiya 
So, I noticed that when skhd + yabai is run from the command-line, there's quite a big bit of difference as compared to running it as a brew service (launchd.plist). This PR sets everything to the highest possible configuration so that these process are not throttled by launchd whatsoever. 

For more info, see here: https://www.manpagez.com/man/5/launchd.plist/