### PR TITLE
Remove deprecated ENV.Ox calls

### DIFF
--- a/skhd.rb
+++ b/skhd.rb
@@ -8,7 +8,6 @@ class Skhd < Formula
   option "with-logging", "Redirect stdout and stderr to log files"
 
   def install
-    ENV.O3
     (var/"log/skhd").mkpath
     system "make", "install"
     bin.install "#{buildpath}/bin/skhd"

--- a/yabai.rb
+++ b/yabai.rb
@@ -12,7 +12,6 @@ class Yabai < Formula
     man.mkpath
 
     if build.head?
-      ENV.O2
       system "make", "install"
     end
 


### PR DESCRIPTION
This fixes #15 and https://github.com/koekeishiya/yabai/issues/817.