### PR TITLE
Don't run skhd clean and build step in parallel.

### DIFF
--- a/skhd.rb
+++ b/skhd.rb
@@ -8,6 +8,7 @@ class Skhd < Formula
   option "with-logging", "Redirect stdout and stderr to log files"
 
   def install
+    ENV.deparallelize
     (var/"log/skhd").mkpath
     system "make", "install"
     bin.install "#{buildpath}/bin/skhd"


### PR DESCRIPTION
The install targets in the skhd makefile depends on both the clean target (which removes the build directory) and the build step. If make is run with concurrency of more than one job, both steps will be run in parallel, resulting in sporadic failures.

Issue #21