### PR TITLE
Caveats — Use non-aliased `which` builtin

### DIFF
--- a/yabai.rb
+++ b/yabai.rb
@@ -35,7 +35,7 @@ class Yabai < Formula
       sudo visudo -f /private/etc/sudoers.d/yabai
 
     Build the configuration row by running:
-      echo "$(whoami) ALL=(root) NOPASSWD: sha256:$(shasum -a 256 $(which yabai) | cut -d " " -f 1) $(which yabai) --load-sa"
+      echo "$(whoami) ALL=(root) NOPASSWD: sha256:$(shasum -a 256 $(\which yabai) | cut -d " " -f 1) $(\which yabai) --load-sa"
 
     README: https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(latest-release)#configure-scripting-addition
     EOS


### PR DESCRIPTION
It fixes the configuration row command when `which` is aliased to something else for convenience.

```shell
❯ unalias which

❯ which which

which: shell built-in command

❯ which yabai

/opt/homebrew/bin/yabai

❯ alias which='which -ap'

❯ which which

/usr/bin/which

❯ which yabai

/opt/homebrew/bin/yabai
/opt/homebrew/bin/yabai

❯ echo "$(whoami) ALL=(root) NOPASSWD: sha256:$(shasum -a 256 $(which yabai) | cut -d " " -f 1) $(which yabai) --load-sa"

paul ALL=(root) NOPASSWD: sha256:5c729cfc728ec8780c14d6fe0bfd74376bd2f057960b542c41106d8e8c5df787
5c729cfc728ec8780c14d6fe0bfd74376bd2f057960b542c41106d8e8c5df787 /opt/homebrew/bin/yabai
/opt/homebrew/bin/yabai --load-sa

❯ echo "$(whoami) ALL=(root) NOPASSWD: sha256:$(shasum -a 256 $(\which yabai) | cut -d " " -f 1) $(\which yabai) --load-sa"

paul ALL=(root) NOPASSWD: sha256:5c729cfc728ec8780c14d6fe0bfd74376bd2f057960b542c41106d8e8c5df787 /opt/homebrew/bin/yabai --load-sa
```