### PR TITLE
Caveats — Fix non-aliased which builtin

### DIFF
--- a/yabai.rb
+++ b/yabai.rb
@@ -36,7 +36,7 @@ class Yabai < Formula
       sudo visudo -f /private/etc/sudoers.d/yabai
 
     Build the configuration row by running:
-      echo "$(whoami) ALL=(root) NOPASSWD: sha256:$(shasum -a 256 $(\which yabai) | cut -d " " -f 1) $(\which yabai) --load-sa"
+      echo "$(whoami) ALL=(root) NOPASSWD: sha256:$(shasum -a 256 $(\\which yabai) | cut -d " " -f 1) $(\\which yabai) --load-sa"
 
     README: https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(latest-release)#configure-scripting-addition
     EOS


### PR DESCRIPTION
Fix #39
Fix c69f65c

A single backslash escapes the character after it. So `\which` just escapes the `w` which gives `which`. We need a double backslash instead: `\\which` → `\which`.