### PR TITLE
Add homebrew service definition

### DIFF
--- a/skhd.rb
+++ b/skhd.rb
@@ -25,6 +25,15 @@ class Skhd < Formula
     EOS
   end
 
+  service do
+    run [opt_bin/"skhd"]
+    run_type :immediate
+    keep_alive successful_exit: false, crashed: true
+    environment_variables PATH: std_service_path_env
+    error_log_path var/"log/skhd.log"
+    log_path var/"log/skhd.log"
+  end
+
   test do
     assert_match "skhd-v#{version}", shell_output("#{bin}/skhd --version")
   end


### PR DESCRIPTION
This enables the user to manage the skhd service using `brew services`

I've used the generated `.plist` file as basis for the service definition to the best of my ability and was able to start the service successfully without any problems.